### PR TITLE
Update build toolchain and target Android 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ ext {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -39,8 +39,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     signingConfigs {
@@ -81,7 +81,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,27 +1,32 @@
 apply plugin: 'com.android.application'
+apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'dagger.hilt.android.plugin'
 
 ext {
-    coroutines_version = "1.6.4"
-    room_version = "2.5.0"
+    coroutines_version = "1.7.3"
+    room_version = "2.6.1"
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
 android {
-    compileSdk 33
+    namespace 'com.farmerbb.appnotifier'
+    compileSdk 34
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId "com.farmerbb.appnotifier"
 
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 9
         versionName "1.2.3"
         resourceConfigurations += ['en', 'fr', 'de', 'sv', 'pl', 'ko', 'it', 'tr']
@@ -38,8 +43,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     signingConfigs {
@@ -73,11 +78,11 @@ android {
             }
         }
     }
-    namespace 'com.farmerbb.appnotifier'
+
+
     lint {
         abortOnError false
     }
-
 }
 
 dependencies {
@@ -86,7 +91,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-rxjava2:$room_version"
     implementation "androidx.room:room-ktx:$room_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,7 @@ java {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.1"
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.farmerbb.appnotifier"
@@ -25,8 +24,8 @@ android {
         targetSdkVersion 33
         versionCode 9
         versionName "1.2.3"
+        resourceConfigurations += ['en', 'fr', 'de', 'sv', 'pl', 'ko', 'it', 'tr']
 
-        resConfigs "en", "fr", "de", "sv", "pl", "ko", "it", "tr"
         vectorDrawables.generatedDensities = []
 
         buildConfigField "long", "TIMESTAMP", "${System.currentTimeMillis()}L"
@@ -74,10 +73,11 @@ android {
             }
         }
     }
-
-    lintOptions {
+    namespace 'com.farmerbb.appnotifier'
+    lint {
         abortOnError false
     }
+
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,23 +4,25 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 ext {
-    coroutines_version = "1.4.2"
-    room_version = "2.2.6"
+    coroutines_version = "1.6.4"
+    room_version = "2.5.0"
 }
 
-repositories {
-    google()
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.1"
 
     defaultConfig {
         applicationId "com.farmerbb.appnotifier"
 
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 9
         versionName "1.2.3"
 
@@ -37,8 +39,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     signingConfigs {
@@ -79,12 +81,12 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-rxjava2:$room_version"
     implementation "androidx.room:room-ktx:$room_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
 
     <uses-permission-sdk-23 android:name="android.permission.QUERY_ALL_PACKAGES" />
 
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+        android:minSdkVersion="34" />
+
     <application
         android:name=".AppNotifierApplication"
         android:allowBackup="true"
@@ -42,7 +46,10 @@
             </intent-filter>
         </activity>
 
-        <service android:name=".AppNotifierService" />
+        <service
+            android:name=".AppNotifierService"
+            android:exported="true"
+            android:foregroundServiceType="specialUse" />
 
         <receiver android:name=".receivers.InstallNotificationClickedReceiver" />
         <receiver android:name=".receivers.InstallNotificationDismissedReceiver" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2020 Braden Farmer
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2020 Braden Farmer
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -18,8 +17,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.farmerbb.appnotifier">
 
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <uses-permission-sdk-23 android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
@@ -33,6 +34,7 @@
 
         <activity
             android:name=".ui.MainActivity"
+            android:exported="true"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -41,19 +43,19 @@
             </intent-filter>
         </activity>
 
-        <service android:name=".AppNotifierService"/>
+        <service android:name=".AppNotifierService" />
 
-        <receiver android:name=".receivers.InstallNotificationClickedReceiver"/>
-        <receiver android:name=".receivers.InstallNotificationDismissedReceiver"/>
-        <receiver android:name=".receivers.UpdateNotificationClickedReceiver"/>
-        <receiver android:name=".receivers.UpdateNotificationDismissedReceiver"/>
+        <receiver android:name=".receivers.InstallNotificationClickedReceiver" />
+        <receiver android:name=".receivers.InstallNotificationDismissedReceiver" />
+        <receiver android:name=".receivers.UpdateNotificationClickedReceiver" />
+        <receiver android:name=".receivers.UpdateNotificationDismissedReceiver" />
 
         <receiver
             android:name=".receivers.BootReceiver"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 
@@ -62,7 +64,7 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.farmerbb.appnotifier">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/com/farmerbb/appnotifier/AppNotifierService.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/AppNotifierService.kt
@@ -18,6 +18,7 @@ package com.farmerbb.appnotifier
 import android.app.PendingIntent
 import android.app.Service
 import android.content.*
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.provider.Settings
 import androidx.core.app.NotificationCompat
@@ -105,7 +106,12 @@ class AppNotifierService: Service() {
             .setColor(ContextCompat.getColor(this, R.color.colorPrimary))
             .setPriority(NotificationCompat.PRIORITY_MIN)
 
-        startForeground(FOREGROUND_SERVICE_ID, builder.build())
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            startForeground(FOREGROUND_SERVICE_ID, builder.build())
+        } else {
+            startForeground(FOREGROUND_SERVICE_ID, builder.build(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/farmerbb/appnotifier/AppNotifierService.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/AppNotifierService.kt
@@ -94,7 +94,7 @@ class AppNotifierService: Service() {
             putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
         }
 
-        val pendingContentIntent = PendingIntent.getActivity(this, 0, contentIntent, FLAGS)
+        val pendingContentIntent = PendingIntent.getActivity(this, 0, contentIntent, getPendingIntentFlags())
 
         val builder = NotificationCompat.Builder(this, channelId)
             .setSmallIcon(R.drawable.ic_info_outline_black_24dp)

--- a/app/src/main/java/com/farmerbb/appnotifier/NotificationController.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/NotificationController.kt
@@ -14,8 +14,8 @@
  */
 
 package com.farmerbb.appnotifier
-
 import android.app.NotificationManager
+
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -119,8 +119,8 @@ class NotificationController @Inject constructor(
             setPackage(BuildConfig.APPLICATION_ID)
         }
 
-        val pendingContentIntent = PendingIntent.getBroadcast(context, 0, contentIntent, FLAGS)
-        val pendingDeleteIntent = PendingIntent.getBroadcast(context, 0, deleteIntent, FLAGS)
+        val pendingContentIntent = PendingIntent.getBroadcast(context, 0, contentIntent, getPendingIntentFlags())
+        val pendingDeleteIntent = PendingIntent.getBroadcast(context, 0, deleteIntent, getPendingIntentFlags())
 
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.app_updated)
@@ -185,8 +185,8 @@ class NotificationController @Inject constructor(
             putExtra(PACKAGE_NAME, packageName)
         }
 
-        val pendingContentIntent = PendingIntent.getBroadcast(context, code, contentIntent, FLAGS)
-        val pendingDeleteIntent = PendingIntent.getBroadcast(context, code, deleteIntent, FLAGS)
+        val pendingContentIntent = PendingIntent.getBroadcast(context, code, contentIntent, getPendingIntentFlags())
+        val pendingDeleteIntent = PendingIntent.getBroadcast(context, code, deleteIntent, getPendingIntentFlags())
 
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.app_updated)

--- a/app/src/main/java/com/farmerbb/appnotifier/NotificationController.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/NotificationController.kt
@@ -185,8 +185,8 @@ class NotificationController @Inject constructor(
             putExtra(PACKAGE_NAME, packageName)
         }
 
-        val pendingContentIntent = PendingIntent.getBroadcast(context, code, contentIntent, getPendingIntentFlags())
-        val pendingDeleteIntent = PendingIntent.getBroadcast(context, code, deleteIntent, getPendingIntentFlags())
+        val pendingContentIntent = PendingIntent.getActivity(context, code, contentIntent, getPendingIntentFlags())
+        val pendingDeleteIntent = PendingIntent.getActivity(context, code, deleteIntent, getPendingIntentFlags())
 
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.app_updated)

--- a/app/src/main/java/com/farmerbb/appnotifier/Utils.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/Utils.kt
@@ -64,7 +64,11 @@ fun Context.isPlayStoreInstalled() = try {
 }
 
 fun getPlayStoreLaunchIntent(packageName: String) = Intent(Intent.ACTION_VIEW).apply {
-    data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+    try {
+        data = Uri.parse("market://details?id=$packageName")
+    } catch (e: ActivityNotFoundException) {
+        data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+    }
 }
 
 fun Context.startActivitySafely(intent: Intent) {

--- a/app/src/main/java/com/farmerbb/appnotifier/Utils.kt
+++ b/app/src/main/java/com/farmerbb/appnotifier/Utils.kt
@@ -90,6 +90,13 @@ fun Context.getPackageInfoSafely(packageName: String, dao: AppUpdateDAO): Packag
     }
 }
 
+fun getPendingIntentFlags(): Int {
+    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        return PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    }
+    return PendingIntent.FLAG_UPDATE_CURRENT
+}
+
 const val FOREGROUND_SERVICE_ID = Integer.MAX_VALUE
 const val APP_UPDATE_ID = Integer.MAX_VALUE - 1
 const val APP_INSTALL_ID = Integer.MAX_VALUE - 2
@@ -97,5 +104,3 @@ const val APP_INSTALL_ID = Integer.MAX_VALUE - 2
 const val APP_INSTALL_GROUP = "app_install_group"
 const val PACKAGE_NAME = "package_name"
 const val PLAY_STORE_PACKAGE = "com.android.vending"
-
-const val FLAGS = PendingIntent.FLAG_UPDATE_CURRENT

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlin_version = "1.8.10"
-        hilt_version = '2.45'
+        kotlin_version = "1.9.22"
+        hilt_version = '2.50'
     }
 
     dependencies {
@@ -11,11 +11,11 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'com.android.application' version '8.2.2' apply false
+    id 'com.android.library' version '8.2.2' apply false
+    id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'se.patrikerdes.use-latest-versions' version '0.2.18'
-    id 'com.github.ben-manes.versions' version '0.45.0'
+    id 'com.github.ben-manes.versions' version '0.51.0'
 }
 
 dependencyUpdates {

--- a/build.gradle
+++ b/build.gradle
@@ -1,35 +1,25 @@
 buildscript {
     ext {
-        kotlin_version = "1.4.21"
-        hilt_version = "2.30.1-alpha"
-    }
-
-    repositories {
-        google()
-        jcenter()
+        kotlin_version = "1.8.10"
+        hilt_version = '2.45'
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }
 }
 
 plugins {
-    id 'se.patrikerdes.use-latest-versions' version '0.2.15'
-    id 'com.github.ben-manes.versions' version '0.36.0'
+    id 'com.android.application' version '7.4.1' apply false
+    id 'com.android.library' version '7.4.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
+    id 'com.github.ben-manes.versions' version '0.45.0'
 }
 
 dependencyUpdates {
     revision = 'release'
-}
-
-allprojects {
-    repositories {
-        jcenter()
-        google()
-    }
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
+    id 'com.android.application' version '8.1.1' apply false
+    id 'com.android.library' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
     id 'se.patrikerdes.use-latest-versions' version '0.2.18'
     id 'com.github.ben-manes.versions' version '0.45.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.unsafe.configuration-cache=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,10 +11,10 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Sun Feb 19 10:03:33 CET 2023
+#org.gradle.java.installations.auto-detect=false
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.unsafe.configuration-cache=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,17 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Sun Feb 19 10:03:33 CET 2023
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.unsafe.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-include ':app'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,40 @@
+pluginManagement {
+
+    /**
+     * The pluginManagement {repositories {...}} block configures the
+     * repositories Gradle uses to search or download the Gradle plugins and
+     * their transitive dependencies. Gradle pre-configures support for remote
+     * repositories such as JCenter, Maven Central, and Ivy. You can also use
+     * local repositories or define your own remote repositories. The code below
+     * defines the Gradle Plugin Portal, Google's Maven repository,
+     * and the Maven Central Repository as the repositories Gradle should use to look for its
+     * dependencies.
+     */
+
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+
+    /**
+     * The dependencyResolutionManagement {repositories {...}}
+     * block is where you configure the repositories and dependencies used by
+     * all modules in your project, such as libraries that you are using to
+     * create your application. However, you should configure module-specific
+     * dependencies in each module-level build.gradle file. For new projects,
+     * Android Studio includes Google's Maven repository and the Maven Central
+     * Repository by default, but it does not configure any dependencies (unless
+     * you select a template that requires some).
+     */
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "AppNotifier"
+include(":app")


### PR DESCRIPTION
This PR updates the toolchain, dependencies and targets Android 33.

Also, repositories to download plugins and dependencies were updated as [JCenter was made read-only](https://blog.gradle.org/jcenter-shutdown).